### PR TITLE
Optimized the hidden listitems2.php (and made it visible)

### DIFF
--- a/php/listitems.php
+++ b/php/listitems.php
@@ -70,7 +70,7 @@ $(document).ready(function() {
 } );
 </script>
 
-<h1><?php te("Items");?> <a title='<?php te("Add new item");?>' href='<?php echo $scriptname;?>?action=edititem&amp;id=new'><img border=0 src='images/add.png'></a></h1>
+<h1><a title='Switch to filter view' href='?action=listitems2'><img border=0 src='images/view.png'></a>&nbsp;&nbsp;&nbsp;&nbsp;<?php te("Items");?> <a title='<?php te("Add new item");?>' href='<?php echo $scriptname;?>?action=edititem&amp;id=new'><img border=0 src='images/add.png'></a></h1>
 
 <table id='itemlisttbl' class="display">
 <thead>


### PR DESCRIPTION
Initially I tried to optimize the listitems.php, until I discovered the
listitems2.php which had exactly what we wanted - a "filter" like view
:D So I did the following with the listitems2.php since it seemed not
fully working:
- Optimized the listitems2.php (many improvements and fixes)
- Added a little link to switch between listitems and listitems2

Unfortunately the Excel export seems not to work, but have no clue how
to fix that and also the software column seems to stay empty / not
filled with data. Any other issues I could not find.

Here some screenshots ;)

BEFORE:
![image](https://cloud.githubusercontent.com/assets/2871833/4628864/065e3e54-539d-11e4-936f-aa4ffe47fc38.png)


AFTER:
Filter view with collapsed table:
![image](https://cloud.githubusercontent.com/assets/2871833/4628849/c291aad0-539c-11e4-9a25-a8161debd42e.png)

Expanded table:
![image](https://cloud.githubusercontent.com/assets/2871833/4628859/ec8fa616-539c-11e4-92e0-50a8844715e9.png)

Switch between normal view (listitems) and filter view (listitems2)
Btw. Hope it's ok that I named it "filter view" and "normal view"
listitems:
![image](https://cloud.githubusercontent.com/assets/2871833/4628932/f004ef08-539d-11e4-8877-85c86e07f60b.png)

listitems2:
![image](https://cloud.githubusercontent.com/assets/2871833/4628918/c93ee64e-539d-11e4-91b8-5237d64e5b9f.png)

