### PR TITLE
Label printing "No text": Hide header-image

### DIFF
--- a/php/printitemlabels_pdf.php
+++ b/php/printitemlabels_pdf.php
@@ -119,6 +119,7 @@ for ($row=1;$row<=$rows;$row++) {
 	if ($wantnotext) {
 		$headertext='';
 		$labeltext='';
+		$image="";
 	}
     
 


### PR DESCRIPTION
When using the no text option, clear also the header image instead of printing one. I know that there is a option to show/hide the header image, but the no text option should superseed this option and overwrite it since the label text, header text and also the header image should be hidden.

Btw: The new option to just print the barcode / qr-code is great :+1: